### PR TITLE
SQLite Docker volume persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+db/db.sqlite3
 
 # Flask stuff:
 instance/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ LABEL maintainer "Jonathan Gazeley"
 RUN apt-get update && apt-get upgrade -y && apt-get autoremove && apt-get autoclean
 
 # Project Files and Settings
-ARG PROJECT=photodb
-ARG PROJECT_DIR=/var/www/${PROJECT}
+ARG PROJECT_DIR=/var/www/photodb
 RUN mkdir -p $PROJECT_DIR
 ADD . $PROJECT_DIR
 WORKDIR $PROJECT_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get autoremove && apt-get autocl
 ARG PROJECT=photodb
 ARG PROJECT_DIR=/var/www/${PROJECT}
 RUN mkdir -p $PROJECT_DIR
-VOLUME ["${PROJECT_DIR}/db"]
 ADD . $PROJECT_DIR
 WORKDIR $PROJECT_DIR
 RUN pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get autoremove && apt-get autocl
 ARG PROJECT=photodb
 ARG PROJECT_DIR=/var/www/${PROJECT}
 RUN mkdir -p $PROJECT_DIR
+VOLUME ["${PROJECT_DIR}/db"]
 ADD . $PROJECT_DIR
 WORKDIR $PROJECT_DIR
 RUN pip install .

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This method of installation is required if you want to work on the source code.
 To create a named container running PhotoDB, use the following command. You can change the `-p` settings
 if you wish to serve PhotoDB on a different port.
 
+A persistent volume will be created to store the SQLite database file.
+
 ```sh
 docker create --name photodb -p 8000:8000 djjudas21/photodb-django
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ if you wish to serve PhotoDB on a different port.
 A persistent volume will be created to store the SQLite database file.
 
 ```sh
-docker create --name photodb -p 8000:8000 djjudas21/photodb-django
+docker create --name photodb --mount source=photodb-sqlite,target=/var/www/photodb/db -p 8000:8000 djjudas21/photodb-django
 ```
 
 ## Configuring PhotoDB

--- a/photodb/settings.py
+++ b/photodb/settings.py
@@ -89,7 +89,7 @@ WSGI_APPLICATION = 'photodb.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'db', 'db.sqlite3'),
     }
 }
 


### PR DESCRIPTION
Move default location of the SQLite database file into a subdirectory and mount this subdirectory as a named volume, so its contents are persistent.

Fixes #90 